### PR TITLE
Make faster for large datasets by only comparing swap distances

### DIFF
--- a/py2opt/solver.py
+++ b/py2opt/solver.py
@@ -38,10 +38,15 @@ class Solver:
             previous_best = self.best_distance
             for swap_first in range(1, self.num_cities - 2):
                 for swap_last in range(swap_first + 1, self.num_cities - 1):
-                    new_route = self.swap(self.best_route, swap_first, swap_last)
-                    new_distance = self.calculate_path_dist(self.distance_matrix, new_route)
-                    self.distances.append(self.best_distance)
-                    if 0 < self.best_distance - new_distance:
+                    before_start = self.best_route[swap_first - 1]
+                    start = self.best_route[swap_first]
+                    end = self.best_route[swap_end]
+                    after_end = self.best_route[swap_end+1]
+                    before = self.distance_matrix[before_start][start] + self.distance_matrix[end][after_end]
+                    after = self.distance_matrix[before_start][end] + self.distance_matrix[start][after_end]
+                    if after < before:
+                        new_route = swap(self.best_route, swap_first, swap_last)
+                        new_distance = self.calculate_path_dist(self.distance_matrix, new_route)
                         self.update(new_route, new_distance)
 
             improvement_factor = 1 - self.best_distance/previous_best

--- a/py2opt/solver.py
+++ b/py2opt/solver.py
@@ -40,12 +40,12 @@ class Solver:
                 for swap_last in range(swap_first + 1, self.num_cities - 1):
                     before_start = self.best_route[swap_first - 1]
                     start = self.best_route[swap_first]
-                    end = self.best_route[swap_end]
-                    after_end = self.best_route[swap_end+1]
+                    end = self.best_route[swap_last]
+                    after_end = self.best_route[swap_last+1]
                     before = self.distance_matrix[before_start][start] + self.distance_matrix[end][after_end]
                     after = self.distance_matrix[before_start][end] + self.distance_matrix[start][after_end]
                     if after < before:
-                        new_route = swap(self.best_route, swap_first, swap_last)
+                        new_route = self.swap(self.best_route, swap_first, swap_last)
                         new_distance = self.calculate_path_dist(self.distance_matrix, new_route)
                         self.update(new_route, new_distance)
 


### PR DESCRIPTION
Thanks for the great introduction to the 2-opt algorithm!  The article and the code were both very helpful for me.

I was able to find one optimization which made it much faster for larger datasets on my old, slow machine.  Instead of recalculating the whole path length every time, I realized that the algorithm only had to compare the distances involved in the swap.  This brought the time for me to calculate the 2-opt path for 1000 randomly-generated cities from 10 minutes down to 5 seconds.

I hope you'll find my contribution useful!  Feel free to correct any mistakes that you see.